### PR TITLE
번역할 챕터 프린트 해 주는 스크립트 추가

### DIFF
--- a/tr_stat.py
+++ b/tr_stat.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+
+import os
+import sys
+
+def extractTitles(src):
+    tmpFn = '/tmp/go-tour.titles'
+    cmdFmt = 'grep "^\* " %s | nl -s ":" > %s'
+    os.system(cmdFmt%(src, tmpFn))
+    return open(tmpFn).readlines()
+
+
+if __name__ == '__main__':
+    enTitles = extractTitles('tour.article.orig')
+    koTitles = extractTitles('tour.article')
+
+    if len(koTitles) != len(enTitles):
+        print "Something wrong?!"
+        sys.exit(0)
+
+    notTranslatedCnt = 0
+    for i in range(len(koTitles)):
+        tKo = koTitles[i]
+        tEn = enTitles[i]
+
+        if tKo == tEn:
+            notTranslatedCnt += 1
+            print tEn.rstrip()
+
+    print "="*79
+    print "%d%% traslated"%(notTranslatedCnt * 100 / len(enTitles))
+
+


### PR DESCRIPTION
어디를 번역해야 되는지 찾는게 번거로와 간단하게 스크립트로 만들었습니다.
두 문서의 제목이 같으면 번역하지 않은 것으로 여기는데,
실제로 번역되었지만 제목은 영문 그대로인 챕터들이 있기 때문에 정확하진 않네요.

$ ./tr_stat.py
     2:\* Go local
     3:\* Packages
    ...
    54% traslated

It compare capter titles of tour.article.orig(en) and tour.article(ko)
And, print it with chapter number if they are same.
